### PR TITLE
V3

### DIFF
--- a/classes/browsers.py
+++ b/classes/browsers.py
@@ -88,7 +88,7 @@ class Browser:
 
         self.logger.info(f'Sending text: {text}')
         try:
-            message_box = WebDriverWait(self.driver, 5).until(
+            message_box = WebDriverWait(self.driver, 10).until(
                 lambda x: x.find_element(By.CLASS_NAME, 'textAreaSlate-9-y-k2'))
             self.actions = ActionChains(self.driver)
             self.actions.click(on_element=message_box)
@@ -104,9 +104,38 @@ class Browser:
             self.refresh()
             return self.send_text(text)
 
+    """ WORK IN PROGRESS
+    def add_react_to_claim(self, message_id: int):
+        self.logger.info(f'Attempting to click: ')
+        xpath_add_react_button = f"//*[@id='chat-messages-{message_id}']//*[@aria-label='Add Reaction']"
+        xpath_emoji_list = f"//html//body//div[1]//div[4]//div//div//div//div[1]//div[2]//div//div//div//div[1]//div[1]//ul//li[1]//button"
+        try:
+            # Get div containing emoji
+            button = WebDriverWait(self.driver, 7).until(lambda x: x.find_element(By.XPATH, xpath_add_react_button))
+            # Click emoji
+            # WebElement.click() breaks for some reason, use javascript instead
+            logging.info("la")
+            self.driver.execute_script('arguments[0].click();', button)
+            logging.info("euh")
+            # Check new count
+            try:
+                WebDriverWait(self.driver, 4)
+                    .until(lambda x: x.find_element(By.XPATH, xpath_emoji_list))
+                self.driver.execute_script('arguments[0].click();', button)
+            except TimeoutException:  # No increase in count
+                self.logger.warning('Emoji was found, but unsuccessfully clicked')
+                raise TimeoutError
+            else:
+                self.logger.info('Emoji successfully clicked')
+        except TimeoutException or NoSuchElementException:
+            self.logger.critical('Unable to find the add button')
+            raise TimeoutError
+    """
+
     def react_emoji(self, reaction: str, message_id: int):
         self.logger.info(f'Attempting to click: {reaction}')
         xpath = f"//*[@id='chat-messages-{message_id}']//*[@id='message-accessories-{message_id}']//*[div]//*[div]//*[div]//*[div]//*[div]"
+
         time.sleep(config.INSTANT_REACT_SPEED)
         try:
             # Get div containing emoji

--- a/classes/browsers.py
+++ b/classes/browsers.py
@@ -104,7 +104,6 @@ class Browser:
             self.refresh()
             return self.send_text(text)
 
-
     def react_emoji(self, reaction: str, message_id: int):
         self.logger.info(f'Attempting to click: {reaction}')
         xpath = f"//*[@id='chat-messages-{message_id}']//*[@id='message-accessories-{message_id}']//*[div]//*[div]//*[div]//*[div]//*[div]"

--- a/classes/timers.py
+++ b/classes/timers.py
@@ -4,7 +4,7 @@ import time
 from config import config
 # import random
 
-launch = True
+launch = True  # Only true when just launched
 
 
 class Timer:
@@ -28,6 +28,8 @@ class Timer:
         Whether a kakera loot is currently available or not.
     """
 
+    tiers = 0  # Says the number of times we can roll our rolls before a claim reset
+
     def __init__(self, browser, next_claim, next_roll, next_daily, claim_available, next_kakera, kakera_available, rolls_at_launch):
         self.browser = browser
         self.claim_timer = next_claim
@@ -47,6 +49,12 @@ class Timer:
         self.logger.info(f'Claim is {"available" if claim_available else "unavailable"}')
         self.logger.info(f'Kakera loot is {"available" if kakera_available else "unavailable"}')
         self.roll_count = rolls_at_launch
+
+    def get_tiers(self):
+        return self.tiers
+
+    def set_tiers(self, t: int):
+        self.tiers = t
 
     def get_claim_availability(self):
         return self.claim_available
@@ -82,6 +90,8 @@ class Timer:
             self.logger.info(f'Roll timer sleeping for {self.time_convert(time_to_sleep)}')
 
             # If we just launched the bot, we roll without waiting for the next interval
+            self.tiers = str(self.claim_timer - datetime.datetime.now()).split(':')[0]
+            # self.logger.info("Tiers: " + str(self.tiers)) # debug
             if not launch:
                 time.sleep(time_to_sleep)
             else:
@@ -93,6 +103,7 @@ class Timer:
             if self.claim_available:
                 self.logger.info(f'Initiating {self.roll_count} rolls')
                 self.browser.roll(self.roll_count)
+            else:
                 if config.ALWAYS_ROLL:
                     self.logger.info(f'Initiating {self.roll_count} rolls')
                     self.browser.roll(self.roll_count)

--- a/classes/timers.py
+++ b/classes/timers.py
@@ -85,16 +85,15 @@ class Timer:
             if not launch:
                 time.sleep(time_to_sleep)
             else:
-                time.sleep(10)
+                time.sleep(5)
                 launch = False
 
             self.roll_timer += datetime.timedelta(minutes=self.roll_duration)
             self.logger.info('Rolls have been reset')
-            if config.ALWAYS_ROLL:
+            if self.claim_available:
                 self.logger.info(f'Initiating {self.roll_count} rolls')
                 self.browser.roll(self.roll_count)
-            else:
-                if self.claim_available:
+                if config.ALWAYS_ROLL:
                     self.logger.info(f'Initiating {self.roll_count} rolls')
                     self.browser.roll(self.roll_count)
                 else:

--- a/config/config.py
+++ b/config/config.py
@@ -29,9 +29,9 @@ ROLL_COMMAND = "wa"
 CLAIM_EMOJI = ":heart:"
 CLAIM_METHOD_CLICK = False  # If True claim will attempt to react on emoji instead of add one (Needs Emoji available)
 # Speed to claim Waifu in lovelist (Currently Fastest Possible)
-INSTANT_CLAIM_SPEED = 0
+INSTANT_CLAIM_SPEED = 15
 # Speed to react on kakera (Default 1 second delay)
-INSTANT_REACT_SPEED = 1
+INSTANT_REACT_SPEED = 15
 # Time between claim resets, in minutes.
 CLAIM_DURATION = 180
 
@@ -40,8 +40,9 @@ CLAIM_DURATION = 180
 ROLL_DURATION = 60
 
 # Time in the hour to start rolling. (Example: 10 means 10 mins before reset. & 50 means 50 minutes before reset.)
-TIME_TO_ROLL = 10
 RANDOM_TIME = True
+TIME_TO_ROLL = 30
+
 # Time between daily command resets, in minutes.
 # Set to 0 to disable auto dailies.
 DAILY_DURATION = 1200
@@ -53,11 +54,19 @@ DAILY_DURATION = 1200
 # Usually 1 hour is sufficient.
 KAKERA_DURATION = 60
 
+# List of emojis the bot is supposed to react to
+# whole list : EMOJI_LIST = ["kakera",	"kakeraT", "kakeraG", "kakeraY", "kakeraO", "kakeraR", "kakeraW", "kakeraL"]
+EMOJI_LIST = ["kakera", "kakeraT", "kakeraG", "kakeraY", "kakeraO", "kakeraR", "kakeraW", "kakeraL"]
+
+# The bot will claim this value or higher if encountered. 0 claims everything
+# if you don't want claiming logic based on kakera, set to 1000000000 or any high number
+CLAIM_KAK = 300
+
 # Maximum number of rolls per reset.
-MAX_ROLLS = 27
+MAX_ROLLS = 8
 
 # Set True to roll every interval despite having claims or not.
-ALWAYS_ROLL = False
+ALWAYS_ROLL = True
 
 LOG_FILE = "logs/log.txt"
 

--- a/main.py
+++ b/main.py
@@ -233,28 +233,29 @@ async def on_ready():
 async def on_reaction_add(reaction, user):
     # We check if it's a mudae reaction
     if user == mudae:
-        embed = reaction.message.embeds[0]
-        # We check if it's claimed
-        if embed.footer.text:
-            match = re.search(r'(?<=Belongs to )\w+', embed.footer.text, re.DOTALL)
-            if match:
-                # if match, it's a kak reaction.
-                # Necessary to do like this to prevent any trolling with fake reactions
-                if reaction.emoji.name in config.EMOJI_LIST and timer.get_kakera_availability():
-                    logging.info(f'Attempting to loot kakera')
-                    try:
-                        await pool.submit(browser.react_emoji, reaction.emoji.name, reaction.message.id)
-                    except TimeoutError:
-                        logging.critical('First Kakera loot failed, could not detect bot reaction')
+        if reaction.message.embeds:
+            embed = reaction.message.embeds[0]
+            # We check if it's claimed
+            if embed.footer.text:
+                match = re.search(r'(?<=Belongs to )\w+', embed.footer.text, re.DOTALL)
+                if match:
+                    # if match, it's a kak reaction.
+                    # Necessary to do like this to prevent any trolling with fake reactions
+                    if reaction.emoji.name in config.EMOJI_LIST and timer.get_kakera_availability():
+                        logging.info(f'Attempting to loot kakera')
                         try:
                             await pool.submit(browser.react_emoji, reaction.emoji.name, reaction.message.id)
                         except TimeoutError:
-                            logging.critical('Second attempt failed. exiting.')
-                            return
-                        else:
-                            await dm_channel.send(content=f"Kakera loot attempted for {reaction.emoji.name}")
-                else:
-                    logging.info("Kak was not in list or timer not up, no attempts made")
+                            logging.critical('First Kakera loot failed, could not detect bot reaction')
+                            try:
+                                await pool.submit(browser.react_emoji, reaction.emoji.name, reaction.message.id)
+                            except TimeoutError:
+                                logging.critical('Second attempt failed. exiting.')
+                                return
+                            else:
+                                await dm_channel.send(content=f"Kakera loot attempted for {reaction.emoji.name}")
+                    else:
+                        logging.info("Kak was not in list or timer not up, no attempts made")
 
 
 @client.event


### PR DESCRIPTION
Added kakera filtering via list in config
-> uses on_reaction_add to 100% get reaction list. Previous method would 90% of the time return an empty reaction list as the reaction isn't there yet when the message is processed

Added claim threshold in config for high kak claims

Added better last claim reaction
-> all rolls get a reaction from bot. When in last hour before reset, will store all unclaimed rolls until we roll config.MAX_ROLL
then proceeds to claim the highest kak with react_emoji function
-> didn't change the "normal" claim method so currently 2 implementations